### PR TITLE
Unsafe pointer

### DIFF
--- a/gosurface/analysis/parser.go
+++ b/gosurface/analysis/parser.go
@@ -188,11 +188,7 @@ func (p UnsafeParser) FindOccurrences(path string, occurrences *[]*Occurrence) {
 		fmt.Printf("Error parsing file %s: %v\n", path, err)
 		return
 	}
-	occurs := false
 	ast.Inspect(node, func(n ast.Node) bool {
-		if occurs { // only count one unsafe per file
-			return false
-		}
 		switch x := n.(type) {
 		case *ast.CallExpr:
 			if sel, ok := x.Fun.(*ast.SelectorExpr); ok {
@@ -202,7 +198,6 @@ func (p UnsafeParser) FindOccurrences(path string, occurrences *[]*Occurrence) {
 						FilePath:   path,
 						LineNumber: fset.Position(x.Pos()).Line,
 					})
-					occurs = true
 				}
 			}
 		}

--- a/gosurface/go.mod
+++ b/gosurface/go.mod
@@ -1,10 +1,3 @@
 module example.com/gosurface
 
 go 1.22.3
-
-require (
-	golang.org/x/mod v0.17.0
-	golang.org/x/tools v0.21.0
-)
-
-require golang.org/x/sync v0.7.0 // indirect

--- a/gosurface/go.sum
+++ b/gosurface/go.sum
@@ -1,6 +1,0 @@
-golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
-golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
-golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.21.0 h1:qc0xYgIbsSDt9EyWz05J5wfa7LOVW0YTLOXrqdLAWIw=
-golang.org/x/tools v0.21.0/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=

--- a/gosurface/main.go
+++ b/gosurface/main.go
@@ -17,6 +17,7 @@ func main() {
 	modulePath := os.Args[1]
 
 	// Get paths of packages imported by module (it includes the main package)
+	// TODO: currently only fetches subdirectories in module, not external dependencies
 	fmt.Printf("Analyzing the dependencies for module: %s", modulePath)
 	dependencies, err := analysis.GetDependencies(modulePath)
 	if err != nil {
@@ -39,15 +40,17 @@ func main() {
 		analysis.AnalyzeModule(dep.Path, &analysis.ExecOccurrences, analysis.ExecParser{})
 		analysis.AnalyzeModule(dep.Path, &analysis.PluginOccurrences, analysis.PluginParser{})
 		analysis.AnalyzeModule(dep.Path, &analysis.GoGenerateOccurrences, analysis.GoGenerateParser{})
+		analysis.AnalyzeModule(dep.Path, &analysis.UnsafeOccurrences, analysis.UnsafeParser{})
 	}
 
 	// Convert occurrences to JSON
-	occurrences := append(append(append(append(
+	occurrences := append(append(append(append(append(
 		analysis.InitOccurrences,
 		analysis.AnonymOccurrences...),
 		analysis.ExecOccurrences...),
 		analysis.PluginOccurrences...),
-		analysis.GoGenerateOccurrences...)
+		analysis.GoGenerateOccurrences...),
+		analysis.UnsafeOccurrences...)
 
 	// Print all the occurrences
 	/*
@@ -72,10 +75,11 @@ func main() {
 	*/
 
 	// Count unique occurrences
-	initCount, anonymCount, osExecCount, pluginCount, goGenerateCount := analysis.CountUniqueOccurrences(occurrences)
+	initCount, anonymCount, osExecCount, pluginCount, goGenerateCount, unsafeCount := analysis.CountUniqueOccurrences(occurrences)
 	fmt.Printf("Unique occurrences of init() function: %d\n", initCount)
 	fmt.Printf("Unique occurrences of initialization with anonymous function: %d\n", anonymCount)
 	fmt.Printf("Unique occurrences of invocation from the os/exec package: %d\n", osExecCount)
 	fmt.Printf("Unique occurrences of plugin dynamically loaded: %d\n", pluginCount)
 	fmt.Printf("Unique occurrences of go:generate directive: %d\n", goGenerateCount)
+	fmt.Printf("Unique occurrences of unsafe pointers: %d\n", unsafeCount)
 }

--- a/gosurface/main.go
+++ b/gosurface/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	// Get paths of packages imported by module (it includes the main package)
 	// TODO: currently only fetches subdirectories in module, not external dependencies
-	fmt.Printf("Analyzing the dependencies for module: %s", modulePath)
+	fmt.Printf("Analyzing module: %s", modulePath)
 	dependencies, err := analysis.GetDependencies(modulePath)
 	if err != nil {
 		fmt.Printf("Error getting dependencies: %v\n", err)


### PR DESCRIPTION
This is a coarse-grained implementation of finding uses of unsafe pointers.

Compare capslock
- Capslock looks at specific cases that are bad for unsafe pointers, such as conversions. (see [comment here](https://github.com/google/capslock/blob/2ba5233e87e9555fe2be71a1ca71da3e54d06a42/interesting/interesting.cm#L393)). This implementation just looks if the `unsafe.Pointer` method is used. 
  - This is not necessarily a bad use, thus "coarse-grained".
- Capslock only counts one occurrence per file, ~so I did similarly (>1 use of unsafe pointers in one file --> 1 occurrence)~

I will test this more thoroughly tomorrow or so.



