### PR TITLE
changes module path to hosting location

### DIFF
--- a/gosurface/go.mod
+++ b/gosurface/go.mod
@@ -1,10 +1,3 @@
-module example.com/gosurface
+module github.com/chains-project/capslock-analysis/gosurface
 
 go 1.22.3
-
-require (
-	golang.org/x/mod v0.17.0
-	golang.org/x/tools v0.21.0
-)
-
-require golang.org/x/sync v0.7.0 // indirect

--- a/gosurface/go.sum
+++ b/gosurface/go.sum
@@ -1,6 +1,0 @@
-golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
-golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
-golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
-golang.org/x/tools v0.21.0 h1:qc0xYgIbsSDt9EyWz05J5wfa7LOVW0YTLOXrqdLAWIw=
-golang.org/x/tools v0.21.0/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=

--- a/gosurface/main.go
+++ b/gosurface/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"example.com/gosurface/analysis"
+	"github.com/chains-project/capslock-analysis/gosurface/analysis"
 )
 
 func main() {


### PR DESCRIPTION
This changes the module path to the hosting location ([ref](https://go.dev/ref/mod#module-path:~:text=A%20module%20path%20should%20describe%20both%20what%20the%20module%20does%20and%20where%20to%20find%20it))

Not sure if you planned to move the module later on?

Also, `go mod tidy`