### PR TITLE
gosurface: Reflection parser

### DIFF
--- a/gosurface/analysis/parser.go
+++ b/gosurface/analysis/parser.go
@@ -18,6 +18,7 @@ type GoGenerateParser struct{}
 type UnsafeParser struct{}
 type CgoParser struct{}
 type IndirectParser struct{}
+type ReflectionParser struct{}
 
 // Parser for init() Function analysis
 func (p InitFuncParser) FindOccurrences(path string, occurrences *[]*Occurrence) {
@@ -315,4 +316,9 @@ func (p IndirectParser) FindOccurrences(path string, occurrences *[]*Occurrence)
 		}
 		return true
 	})
+}
+
+func (p ReflectionParser) FindOccurrences(path string, occurrences *[]*Occurrence) {
+
+	// todo
 }

--- a/gosurface/analysis/parser.go
+++ b/gosurface/analysis/parser.go
@@ -334,6 +334,7 @@ func (p ReflectParser) FindOccurrences(path string, occurrences *[]*Occurrence) 
 					AttackVector: "reflect",
 					FilePath:     path,
 					LineNumber:   fset.Position(x.Pos()).Line})
+				return false
 			}
 		}
 		return true

--- a/gosurface/analysis/utilities.go
+++ b/gosurface/analysis/utilities.go
@@ -33,7 +33,7 @@ var (
 	UnsafeOccurrences     []*Occurrence
 	CgoOccurrences        []*Occurrence
 	IndirectOccurrences   []*Occurrence
-	ReflectionOccurrences []*Occurrence
+	ReflectOccurrences    []*Occurrence
 )
 
 type OccurrenceParser interface {
@@ -162,7 +162,7 @@ func AnalyzeModule(path string, occurrences *[]*Occurrence, parser OccurrencePar
 	})
 }
 
-func CountUniqueOccurrences(occurrences []*Occurrence) (initCount, anonymCount, execCount, pluginCount, goGenerateCount, unsafeCount, cgoCount, indirectCount, reflectionCount int) {
+func CountUniqueOccurrences(occurrences []*Occurrence) (initCount, anonymCount, execCount, pluginCount, goGenerateCount, unsafeCount, cgoCount, indirectCount, reflectCount int) {
 	initOccurrences := make(map[string]struct{})
 	anonymOccurrences := make(map[string]struct{})
 	execOccurrences := make(map[string]struct{})
@@ -171,7 +171,7 @@ func CountUniqueOccurrences(occurrences []*Occurrence) (initCount, anonymCount, 
 	unsafeOccurrences := make(map[string]struct{})
 	cgoOccurrences := make(map[string]struct{})
 	indirectOccurrences := make(map[string]struct{})
-	reflectionOccurrences := make(map[string]struct{})
+	reflectOccurrences := make(map[string]struct{})
 
 	for _, occ := range occurrences {
 		switch occ.AttackVector {
@@ -199,13 +199,13 @@ func CountUniqueOccurrences(occurrences []*Occurrence) (initCount, anonymCount, 
 		case "indirect":
 			key := fmt.Sprintf("%s:%s:%s:%d", occ.MethodInvoked, occ.TypePassed, occ.FilePath, occ.LineNumber)
 			indirectOccurrences[key] = struct{}{}
-		case "reflection":
+		case "reflect":
 			key := fmt.Sprintf("%s:%s:%d", occ.MethodInvoked, occ.FilePath, occ.LineNumber)
-			reflectionOccurrences[key] = struct{}{}
+			reflectOccurrences[key] = struct{}{}
 		}
 	}
 
-	return len(initOccurrences), len(anonymOccurrences), len(execOccurrences), len(pluginOccurrences), len(goGenerateOccurrences), len(unsafeOccurrences), len(cgoOccurrences), len(indirectOccurrences), len(reflectionOccurrences)
+	return len(initOccurrences), len(anonymOccurrences), len(execOccurrences), len(pluginOccurrences), len(goGenerateOccurrences), len(unsafeOccurrences), len(cgoOccurrences), len(indirectOccurrences), len(reflectOccurrences)
 }
 
 type OccurrenceJSON struct {

--- a/gosurface/analysis/utilities.go
+++ b/gosurface/analysis/utilities.go
@@ -33,13 +33,15 @@ var (
 	UnsafeOccurrences     []*Occurrence
 	CgoOccurrences        []*Occurrence
 	IndirectOccurrences   []*Occurrence
+	ReflectionOccurrences []*Occurrence
 )
 
 type OccurrenceParser interface {
 	FindOccurrences(path string, occurrences *[]*Occurrence)
 }
 
-func GetDependencies(modulePath string) ([]Dependency, error) {
+// Gets all go files in given path.
+func GetDependencies(modulePath string) ([]Dependency, error) { // TODO should rename this one. If getting dependencies, we look at the go.mod file.
 
 	var dependencies []Dependency
 
@@ -160,7 +162,7 @@ func AnalyzeModule(path string, occurrences *[]*Occurrence, parser OccurrencePar
 	})
 }
 
-func CountUniqueOccurrences(occurrences []*Occurrence) (initCount, anonymCount, execCount, pluginCount, goGenerateCount, unsafeCount, cgoCount, indirectCount int) {
+func CountUniqueOccurrences(occurrences []*Occurrence) (initCount, anonymCount, execCount, pluginCount, goGenerateCount, unsafeCount, cgoCount, indirectCount, reflectionCount int) {
 	initOccurrences := make(map[string]struct{})
 	anonymOccurrences := make(map[string]struct{})
 	execOccurrences := make(map[string]struct{})
@@ -169,6 +171,7 @@ func CountUniqueOccurrences(occurrences []*Occurrence) (initCount, anonymCount, 
 	unsafeOccurrences := make(map[string]struct{})
 	cgoOccurrences := make(map[string]struct{})
 	indirectOccurrences := make(map[string]struct{})
+	reflectionOccurrences := make(map[string]struct{})
 
 	for _, occ := range occurrences {
 		switch occ.AttackVector {
@@ -196,10 +199,13 @@ func CountUniqueOccurrences(occurrences []*Occurrence) (initCount, anonymCount, 
 		case "indirect":
 			key := fmt.Sprintf("%s:%s:%s:%d", occ.MethodInvoked, occ.TypePassed, occ.FilePath, occ.LineNumber)
 			indirectOccurrences[key] = struct{}{}
+		case "reflection":
+			key := fmt.Sprintf("%s:%s:%d", occ.MethodInvoked, occ.FilePath, occ.LineNumber)
+			reflectionOccurrences[key] = struct{}{}
 		}
 	}
 
-	return len(initOccurrences), len(anonymOccurrences), len(execOccurrences), len(pluginOccurrences), len(goGenerateOccurrences), len(unsafeOccurrences), len(cgoOccurrences), len(IndirectOccurrences)
+	return len(initOccurrences), len(anonymOccurrences), len(execOccurrences), len(pluginOccurrences), len(goGenerateOccurrences), len(unsafeOccurrences), len(cgoOccurrences), len(indirectOccurrences), len(reflectionOccurrences)
 }
 
 type OccurrenceJSON struct {

--- a/gosurface/main.go
+++ b/gosurface/main.go
@@ -57,7 +57,7 @@ Y8,        88  8b       d8          '8b  88       88  88            88     ,adPP
 		analysis.AnalyzeModule(dep.Path, &analysis.UnsafeOccurrences, analysis.UnsafeParser{})
 		analysis.AnalyzeModule(dep.Path, &analysis.CgoOccurrences, analysis.CgoParser{})
 		analysis.AnalyzeModule(dep.Path, &analysis.IndirectOccurrences, analysis.IndirectParser{})
-		analysis.AnalyzeModule(dep.Path, &analysis.ReflectionOccurrences, analysis.ReflectionParser{})
+		analysis.AnalyzeModule(dep.Path, &analysis.ReflectOccurrences, analysis.ReflectParser{})
 	}
 
 	// Convert occurrences to JSON
@@ -70,17 +70,17 @@ Y8,        88  8b       d8          '8b  88       88  88            88     ,adPP
 		analysis.UnsafeOccurrences...),
 		analysis.CgoOccurrences...),
 		analysis.IndirectOccurrences...),
-		analysis.ReflectionOccurrences...)
+		analysis.ReflectOccurrences...)
 	// Print occurrences
 	// analysis.PrintOccurrences(analysis.IndirectOccurrences)
 	// analysis.PrintOccurrences(occurrences)
 
 	// Count unique occurrences
-	initCount, anonymCount, osExecCount, pluginCount, goGenerateCount, unsafeCount, cgoCount, indirectCount, reflectionCount := analysis.CountUniqueOccurrences(occurrences)
+	initCount, anonymCount, osExecCount, pluginCount, goGenerateCount, unsafeCount, cgoCount, indirectCount, reflectCount := analysis.CountUniqueOccurrences(occurrences)
 	fmt.Println()
 	fmt.Println()
 	fmt.Println("╔══════════════════════════════════════════════════════════════╗")
-	fmt.Printf("║ Attack Surface Analysis: %s			║\n", filepath.Base(strings.TrimSuffix(modulePath, "/"+filepath.Base(modulePath))))
+	fmt.Printf("║ Attack Surface Analysis: %s			       ║\n", filepath.Base(strings.TrimSuffix(modulePath, "/"+filepath.Base(modulePath))))
 	fmt.Println("╠══════════════════════════════════════════════════════════════╣")
 	fmt.Printf("║ Unique occurrences of init() function:            %10d ║\n", initCount)
 	fmt.Printf("║ Initialization with anonymous function:           %10d ║\n", anonymCount)
@@ -90,6 +90,6 @@ Y8,        88  8b       d8          '8b  88       88  88            88     ,adPP
 	fmt.Printf("║ Unsafe pointers:                                  %10d ║\n", unsafeCount)
 	fmt.Printf("║ CGO pointers:                                     %10d ║\n", cgoCount)
 	fmt.Printf("║ Indirect method calls via interfaces:             %10d ║\n", indirectCount)
-	fmt.Printf("║ Uses of reflection:				                %10d ║\n", reflectionCount)
+	fmt.Printf("║ Imports of reflection:			    %10d ║\n", reflectCount)
 	fmt.Println("╚══════════════════════════════════════════════════════════════╝")
 }

--- a/gosurface/main.go
+++ b/gosurface/main.go
@@ -57,10 +57,11 @@ Y8,        88  8b       d8          '8b  88       88  88            88     ,adPP
 		analysis.AnalyzeModule(dep.Path, &analysis.UnsafeOccurrences, analysis.UnsafeParser{})
 		analysis.AnalyzeModule(dep.Path, &analysis.CgoOccurrences, analysis.CgoParser{})
 		analysis.AnalyzeModule(dep.Path, &analysis.IndirectOccurrences, analysis.IndirectParser{})
+		analysis.AnalyzeModule(dep.Path, &analysis.ReflectionOccurrences, analysis.ReflectionParser{})
 	}
 
 	// Convert occurrences to JSON
-	occurrences := append(append(append(append(append(append(append(
+	occurrences := append(append(append(append(append(append(append(append(
 		analysis.InitOccurrences,
 		analysis.AnonymOccurrences...),
 		analysis.ExecOccurrences...),
@@ -68,14 +69,14 @@ Y8,        88  8b       d8          '8b  88       88  88            88     ,adPP
 		analysis.GoGenerateOccurrences...),
 		analysis.UnsafeOccurrences...),
 		analysis.CgoOccurrences...),
-		analysis.IndirectOccurrences...)
-
+		analysis.IndirectOccurrences...),
+		analysis.ReflectionOccurrences...)
 	// Print occurrences
 	// analysis.PrintOccurrences(analysis.IndirectOccurrences)
 	// analysis.PrintOccurrences(occurrences)
 
 	// Count unique occurrences
-	initCount, anonymCount, osExecCount, pluginCount, goGenerateCount, unsafeCount, cgoCount, indirectCount := analysis.CountUniqueOccurrences(occurrences)
+	initCount, anonymCount, osExecCount, pluginCount, goGenerateCount, unsafeCount, cgoCount, indirectCount, reflectionCount := analysis.CountUniqueOccurrences(occurrences)
 	fmt.Println()
 	fmt.Println()
 	fmt.Println("╔══════════════════════════════════════════════════════════════╗")
@@ -89,5 +90,6 @@ Y8,        88  8b       d8          '8b  88       88  88            88     ,adPP
 	fmt.Printf("║ Unsafe pointers:                                  %10d ║\n", unsafeCount)
 	fmt.Printf("║ CGO pointers:                                     %10d ║\n", cgoCount)
 	fmt.Printf("║ Indirect method calls via interfaces:             %10d ║\n", indirectCount)
+	fmt.Printf("║ Uses of reflection:				                %10d ║\n", reflectionCount)
 	fmt.Println("╚══════════════════════════════════════════════════════════════╝")
 }


### PR DESCRIPTION
This implements a simple parser that identifies imports of the reflect package.

**Motivation**
[Capslock only looks at imports of reflect](https://github.com/google/capslock/blob/main/docs/README.md#interpreting-capability-reports:~:text=The%20static%20analysis%20is%20unable%20to%20determine%20the%20behavior%20of%20all%20code%20using%20reflect%2C%20so%20it%20falls%20back%20to%20reporting%20to%20the%20user%20that%20the%20code%20has%20the%20REFLECT%20capability.%20Users%20can%20then%20inspect%20the%20functions%20the%20analysis%20points%20to%20if%20they%20wish.) as it is difficult to determine good/bad uses of reflect. This (allegedly) requires manual analysis. 

WDYT?

